### PR TITLE
feat: pick default module from async imports of axios and bowser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@infermedica/modular-analytics",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@infermedica/modular-analytics",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^16.11.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@infermedica/modular-analytics",
   "description": "Modular analytics interface",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "author": "Infermedica",
   "license": "MIT",
   "main": "src/index.js",

--- a/src/modules.js
+++ b/src/modules.js
@@ -234,7 +234,7 @@ if (__analytics.infermedicaAnalytics.isEnabled) {
 
     const initializeBrowser = async () => {
       if (browser === null) {
-        const Bowser = await import('bowser');
+        const { default: Bowser } = await import('bowser');
         browser = Bowser.getParser(window.navigator.userAgent);
       }
       return Promise.resolve(browser);
@@ -242,7 +242,7 @@ if (__analytics.infermedicaAnalytics.isEnabled) {
 
     const initializeAxios = async () => {
       if (analyticsApi === null) {
-        const axios = await import('axios');
+        const { default: axios } = await import('axios');
 
         analyticsApi = axios.create({
           baseURL,


### PR DESCRIPTION
This improvement is required for all projects that use webpack 5.

Without this change, 2 errors are thrown.
```
Bowser.getParser is not a function
axios.create is not a function
```
The reason for that is the difference between webpack 4 and 5.
For example in webpack 4 all properties from `axios.default` were copied to `axios`, then we could use create function, but in webpack 5 we have only `default` getter.

I checked this change for project with webpack 4 and webpack 5 and it works for both.