### PR TITLE
hotfix: add \`./\` to the exports in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@infermedica/modular-analytics",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "license": "MIT",
   "main": "src/index.js",
   "exports": {
-    ".": "src/index.js",
-    "./vue": "src/vue.js"
+    ".": "./src/index.js",
+    "./vue": "./src/vue.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@infermedica/modular-analytics",
   "description": "Modular analytics interface",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "author": "Infermedica",
   "license": "MIT",
   "main": "src/index.js",


### PR DESCRIPTION
This is a fix for an `Error: [ERR_INVALID_PACKAGE_TARGET]`
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/13744352/167403211-f1ad9918-7f8c-4dc4-9181-6a274d5516cb.png">
