### PR TITLE
feat: replace Bowser with ua-parser-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
       "max-len": [
         "error",
         {
-          "code": 120
+          "code": 120,
+          "ignoreComments": true
         }
       ]
     }

--- a/src/modules.js
+++ b/src/modules.js
@@ -319,21 +319,16 @@ function infermedicaModule() {
       const date = new Date();
       const { user, application } = filteredProperties;
 
-      const userDeviceFallback = {
+      const userDeviceValuesWithFallback = {
         browser: {
           name: '',
           version: '',
+          ...browser.browser,
         },
         os: {
           name: '',
+          ...browser.os,
         },
-        platform: {
-          type: '',
-        },
-      };
-      const userDeviceValues = {
-        browser: browser.browser,
-        os: browser.os,
         platform: {
           ...browser.device,
           // Providing 'desktop' as default type value as ua-parser-js adds device.type only when explicitly defined in UA, e.g. 'Mobile Safari'
@@ -352,7 +347,7 @@ function infermedicaModule() {
         user: {
           ...user,
           id: getUid(),
-          ...{ ...userDeviceFallback, ...userDeviceValues },
+          ...userDeviceValuesWithFallback,
         },
         event_details: {
           event_type: '',

--- a/src/modules.js
+++ b/src/modules.js
@@ -318,6 +318,31 @@ function infermedicaModule() {
       );
       const date = new Date();
       const { user, application } = filteredProperties;
+
+      const userDeviceFallback = {
+        browser: {
+          name: '',
+          version: '',
+        },
+        os: {
+          name: '',
+        },
+        platform: {
+          type: '',
+        },
+      };
+      const userDeviceValues = {
+        browser: browser.browser,
+        os: browser.os,
+        platform: {
+          ...browser.device,
+          // Providing 'desktop' as default type value as ua-parser-js adds device.type only when explicitly defined in UA, e.g. 'Mobile Safari'
+          // More context - https://github.com/faisalman/ua-parser-js/issues/182#issuecomment-263115448
+          type: browser.device?.type ?? 'desktop',
+        },
+        user_agent: browser.ua,
+      };
+
       const data = {
         ...filteredProperties,
         date,
@@ -327,14 +352,7 @@ function infermedicaModule() {
         user: {
           ...user,
           id: getUid(),
-          browser: browser.browser,
-          os: browser.os,
-          platform: {
-            ...browser.device,
-            // Providing 'desktop' as default type value as ua-parser-js adds device.type only when explicitly defined in UA, e.g. 'Mobile Safari'
-            // More context - https://github.com/faisalman/ua-parser-js/issues/182#issuecomment-263115448
-            type: browser.device?.type ?? 'desktop',
-          },
+          ...{ ...userDeviceFallback, ...userDeviceValues },
         },
         event_details: {
           event_type: '',

--- a/src/modules.js
+++ b/src/modules.js
@@ -330,7 +330,7 @@ function infermedicaModule() {
           version: browser.version ?? '',
         },
         os: {
-          ...browser.os,
+          ...os,
           name: os.name ?? '',
         },
         platform: {

--- a/src/modules.js
+++ b/src/modules.js
@@ -331,7 +331,7 @@ function infermedicaModule() {
           os: browser.os,
           platform: {
             ...browser.device,
-            // Providing default type as ua-parser-js adds device.type only for non-desktop devices
+            // Providing 'desktop' as default type value as ua-parser-js adds device.type only when explicitly defined in UA, e.g. 'Mobile Safari'
             // More context - https://github.com/faisalman/ua-parser-js/issues/182#issuecomment-263115448
             type: browser.device?.type ?? 'desktop',
           },

--- a/tests/modules/infermedicaAnalytics.test.js
+++ b/tests/modules/infermedicaAnalytics.test.js
@@ -19,9 +19,10 @@ const expectedPayload = {
       },
       user: {
         id: null,
-        browser: 'browser',
-        os: 'os',
-        platform: { type: 'platform' },
+        browser: { name: '', version: '' },
+        os: { name: '' },
+        platform: { type: 'desktop' },
+        user_agent: 'user_agent',
       },
     },
   }],
@@ -29,9 +30,10 @@ const expectedPayload = {
 };
 jest.mock('ua-parser-js', () => (
   () => ({
-    browser: 'browser',
-    os: 'os',
-    device: { type: 'platform' },
+    browser: {},
+    os: {},
+    device: {},
+    ua: 'user_agent',
   })
 ));
 


### PR DESCRIPTION
`Bowser` is not maintained anymore and we run into issues where it wasn't correctly parsing newer Safari versions. `ua-parser-js` was found as replacement, as it's still actively maintained and parses all recent versions of major browsers.

Closes #26 