### PR TITLE
fix: trackEvent not working in debug mode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,10 +36,13 @@ export const Analytics = {
    */
   trackEvent(eventName, properties, modules) {
     const responses = analyticModules.map((analyticModule) => {
-      const moduleRegistered = modules && modules.includes(analyticModule.name);
-      const hasTrackEvent = ('trackEvent' in analyticModule);
+      if (analyticModule.name !== 'debug') {
+        const moduleRegistered = modules && modules.includes(analyticModule.name);
+        const hasTrackEvent = ('trackEvent' in analyticModule);
 
-      if (!moduleRegistered || !hasTrackEvent) return [];
+        if (!moduleRegistered || !hasTrackEvent) return [];  
+      }
+      
       return analyticModule.trackEvent(eventName, { ...globalProperties, ...properties });
     }).flat();
 

--- a/src/modules.js
+++ b/src/modules.js
@@ -33,6 +33,7 @@ function debugModule() {
     },
     trackEvent(eventName, properties) {
       console.log('Analytics (trackEvent):', eventName, properties);
+      return new Promise((resolve) => resolve(200))
     },
   };
 }


### PR DESCRIPTION
fixed: When debug mode was enabled `trackEvent` method wasn't called.